### PR TITLE
Remove last step of Release Action

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,9 +20,3 @@ jobs:
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
           access: public
-      - name: Resync Maintenance
-        if: ${{ endsWith(github.ref, '.0') }}
-        run: |
-          git checkout maintenance
-          git reset --hard origin/main
-          git push --force origin maintenance


### PR DESCRIPTION
## Description

Failed action again, don't believe we need this now? Worth noting we did successfully publish to npm as part of that last action though: https://www.npmjs.com/package/@flowforge/node-red-function-gpt

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

