### PR TITLE
Change settings.functionExternalModules to settings.functionGptExternalModules

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ module.exports = function(RED) {
     RED.nodes.registerType("function-gpt", FunctionGPTNode, {
         dynamicModuleList: "libs",
         settings: {
-            functionExternalModules: { value: true, exportable: true }
+            functionGptExternalModules: { value: true, exportable: true }
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowforge/node-red-function-gpt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Variation of the standard Node-RED function node that includes an interface to ChatGPT for writing into the function content.",
   "author": {
     "name": "Joe Pavitt",


### PR DESCRIPTION
## Description

Users [reporting](https://github.com/flowforge/node-red-function-gpt/issues/16#issuecomment-1540276915) seeing a warning on install of the nodes. This may be causing the issue raised [here](https://github.com/flowforge/node-red-function-gpt/issues/16) but difficult to verify at the moment as it doesn't occur when running in my local Node-RED development environment.

## Related Issue(s)

#16 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
