### PR TITLE
0.2.1 - Change POST to relative path

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@
                         }
                     }
                     currentXhr = $.ajax({
-                        url: "/function-gpt-ask/" + node.id,
+                        url: "function-gpt-ask/" + node.id,
                         type: "POST",
                         data: {
                             prompt,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowforge/node-red-function-gpt",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Variation of the standard Node-RED function node that includes an interface to ChatGPT for writing into the function content.",
   "author": {
     "name": "Joe Pavitt",


### PR DESCRIPTION
## Description

We call the POST with an absolute URL, this should be relative to account for varying Editor paths.

## Related Issue(s)

Fixes #16 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)